### PR TITLE
take min/max values instead of first/last of seq function

### DIFF
--- a/plot_twisst.R
+++ b/plot_twisst.R
@@ -235,7 +235,7 @@ smooth.twisst <- function(twisst_object, span=0.05, span_bp=NULL, spacing=NULL) 
         
         if (is.null(spacing) == TRUE) spacing <- twisst_object$length[[i]]*span*.1
         
-        l$pos[[i]] <- seq(twisst_object$pos[[i]][1], tail(twisst_object$pos[[i]],1), spacing)
+        l$pos[[i]] <- seq(min(twisst_object$pos[[i]][1]), max(twisst_object$pos[[i]],1), spacing)
         
         l$weights[[i]] <- smooth.weights(twisst_object$pos[[i]], twisst_object$weights[[i]], new_x <- l$pos[[i]], span = span,
                                          window_sites=twisst_object$window_data$sites[[i]])


### PR DESCRIPTION
Fixes https://github.com/simonhmartin/twisst/issues/12

when assigning l$pos[[i]] inside smooth.twisst, seq function seemed to pick the chronological first and last values in pos.
However, some users may produce window_data_files with columns that are not sorted (mine was sorted 'naively' on command line, hence lexicographic sorting), and the error was caused by seq recieving values in which from < to. 

Using instead the min/max values in the column can fix this,
data not being sorted causes further issues, for example with plot.twisst, so a more holistic solution may be better.

Cheers, thank you for this tool!